### PR TITLE
markov generation optimizations (#6)

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,15 +32,15 @@ parser.add_argument('--slack_app_token',
 parser.add_argument('-b', '--brain',
                     env_var="CB_BRAIN",
                     required=True,
-                    help="This bot's brain as a YAML file.")
+                    help="This bot's input brain as a YAML or newline-delimited text file.")
+parser.add_argument('-o', '--output',
+                    env_var="CB_OUTPUT",
+                    required=True,
+                    help="File for writing the updated corpus")
 parser.add_argument('-n', '--name',
                     env_var="CB_NAME",
                     required=True,
                     help="The name this bot will respond to in chats.")
-parser.add_argument('--skip_mp',
-                    env_var="CB_SKIP_MP",
-                    action="store_true",
-                    help="Skip the multiprocess stuff that can hinder debugging.")
 args = parser.parse_args()
 
 discord_token = args.discord_token
@@ -48,7 +48,7 @@ slack_bot_token = args.slack_bot_token
 slack_app_token = args.slack_app_token
 
 bot_name = args.name
-brain = Markov(args.brain, bot_name.upper(), args.skip_mp)
+brain = Markov(args.brain, args.output, [bot_name])
 
 discord_client = discord.Client()
 

--- a/markov.py
+++ b/markov.py
@@ -1,130 +1,151 @@
-import yaml
 import random
-from secrets import SystemRandom
-from multiprocess import Lock, Manager, Process
+import yaml
+from itertools import chain, groupby
 
+START_TOK = "<START>"
+STOP_TOK = "<STOP>"
+
+STOP = object()
+START = object()
 
 # instantiate a Markov object with the source file
 class Markov:
-    def __init__(self, brain_file: str, ignore_words, skip_mp=False):
-        self.brain_file = brain_file
-        self.ignore_words = ignore_words
-        self.skip_mp = skip_mp
-        if not self.skip_mp:
-            self.manager = Manager()
-            self.words = self.manager.list(self.load_corpus(brain_file))
-            self.cache = self.manager.dict(self.database(self.words, {}))
-        else:
-            self.words = list(self.load_corpus(brain_file))
-            self.cache = dict(self.database(self.words, {}))
+    def __init__(self, input_file: str, output_file: str, ignore_words):
+        if input_file == output_file:
+            raise ValueError("input and output files must be different")
 
-    @classmethod
-    def load_corpus(cls, source_file: str):
+        self.ignore_words = set(w.upper() for w in ignore_words)
+        self.output_file = output_file
+        self.update_graph_and_corpus(self.corpus_iter(input_file), init=True)
+
+    def corpus_iter(self, source_file: str):
+        """
+        Emit the contents of the source_file as an iterable of token sequences
+        """
         with open(source_file, 'r') as infile:
-            return yaml.load(infile.read(), Loader=yaml.Loader)
+            # this is dumb
+            if source_file.endswith(".yml") or source_file.endswith(".yaml"):
+                words = yaml.load(infile.read(), Loader=yaml.Loader)
+                for is_delim, phrase in groupby(words, lambda w: w in (START_TOK, STOP_TOK)):
+                    if not is_delim:
+                        yield list(phrase)
+            else:
+                for line in infile:
+                    yield from self.tokenize(line)
+
 
     @classmethod
-    def generate_markov_text(cls, words: list, cache: dict, seed_phrase=None):
-        w1, w2 = "<START>", ""
-        if seed_phrase:
-            w1, w2 = seed_phrase[0], seed_phrase[1]
-        else:
-            urandom = SystemRandom()
-            valid_starts = [(x[0], x[1]) for x in cache.keys() if x[0] == "<START>"]
-            w1, w2 = valid_starts[urandom.randint(0, len(valid_starts) - 1)]
+    def triples_and_stop(cls, words):
+        """
+        Emit 3-grams from the sequence of words, the last one ending with the
+        special STOP token
+        """
+        words = chain(words, [STOP])
+        try:
+            w1 = next(words)
+            w2 = next(words)
+            w3 = next(words)
+            while True:
+                yield (w1, w2, w3)
+                w1, w2, w3 = w2, w3, next(words)
+        except StopIteration:
+            return
 
-        gen_words = []
+    def _ignore(self, word: str):
+        return word.strip("\'\"!@#$%^&*().,/\\+=<>?:;").upper() in self.ignore_words
+
+    def tokenize(self, sentence: str):
+        """
+        Emit a sequence of token lists from the string, ignoring ignore_words.
+        A word ending in certain puntuation ends a given token sequence.
+        """
+        cur = []
+        for w in sentence.split():
+            if self._ignore(w):
+                pass
+
+            elif any(w.endswith(c) for c in ('.', '?', '!')):
+                w = w.strip(".?!")
+                if w:
+                    cur.append(w)
+                yield(cur)
+                cur = []
+            else:
+                cur.append(w)
+        if cur:
+            yield cur
+
+    def _update_graph_and_emit_changes(self, token_seqs, init=False):
+        """
+        self.graph stores the graph of n-gram trasitions.
+        The keys are single tokens or pairs and the values possible next words in the n-gram.
+        Initial tokens are also specially added to the list at the key START.
+
+        _update_graph_and_emit_changes returns a generator that when run will
+        update the graph with the ngrams taken from each element of token_seqs.
+
+        Yields the token sequence that result in updates so they can be further
+        acted on.
+
+        if init is True reinitialize from an empty graph
+        """
+        if init:
+            self.graph = {START: []}
+
+        for seq in token_seqs:
+            first = True
+            learned = False
+            for w1, w2, w3 in self.triples_and_stop(seq):
+                if first:
+                    if w1 not in self.graph[START]:
+                        self.graph[START].append(w1)
+                        learned = True
+                    next_words = self.graph.setdefault(w1, [])
+                    if w2 not in next_words:
+                        next_words.append(w2)
+                        learned = True
+                    first = False
+                next_words = self.graph.setdefault((w1, w2), [])
+                if w3 not in next_words:
+                    next_words.append(w3)
+                    learned = True
+            if learned:
+                yield seq
+
+    def update_graph_and_corpus(self, token_seqs, init=False):
+        changes = self._update_graph_and_emit_changes(token_seqs, init=init)
+        self.update_corpus(changes, init=init)
+
+    def update_corpus(self, token_seqs, init=False):
+        mode = 'w' if init else 'a'
+        with open(self.output_file, mode) as f:
+            for seq in token_seqs:
+                f.write(" ".join(seq))
+                f.write("\n")
+
+    def generate_markov_text(self, seed=None):
+        if seed and seed in self.graph:
+            w1 = seed
+        else:
+            w1 = random.choice(self.graph[START])
+        w2 = random.choice(self.graph[w1])
+
+        gen_words = [w1]
         while True:
-            if w2 == "<STOP>":
+            if w2 == STOP:
                 break
-            w1, w2 = w2, random.choice(cache[(w1, w2)])
+            w1, w2 = w2, random.choice(self.graph[(w1, w2)])
             gen_words.append(w1)
 
         message = ' '.join(gen_words)
         return message
 
-    @classmethod
-    def triples(cls, words):
-        if len(words) < 3:
-            return
-        for i in range(len(words) - 2):
-            yield (words[i], words[i+1], words[i+2])
-
-    def database(self, words: list, cache: dict):
-        for w1, w2, w3 in self.triples(words):
-            key = (w1, w2)
-            if key in cache:
-                if not (w3 in cache[key]):
-                    cache[key].append(w3)
-            else:
-                cache[key] = [w3]
-        return cache
-
-    def learn(self, sentence: str):
-        tokens = sentence.split()
-
-        # strip, uppercase, and check for inclusion in IGNORE_WORDS list
-        is_ignored = lambda x: x.strip("\'\"!@#$%^&*().,/\\+=<>?:;").upper() in self.ignore_words
-        tokens = [x for x in tokens if not is_ignored(x)]
-        if len(tokens) == 0:
-            return  # nothing to learn here!
-
-        tokens[len(tokens) - 1] = tokens[len(tokens) - 1].strip(".?!")
-        tokens = [u"<START>"] + tokens + [u"<STOP>"]
-        indexes_with_stops = [tokens.index(x) for x in tokens if x.strip(".?!") != x]
-        for i in indexes_with_stops[::-1]:
-            tokens[i] = tokens[i].strip(".?!")
-            tokens.insert(i + 1, u"<STOP>")
-            tokens.insert(i + 2, u"<START>")
-
-        self.words += tokens
-        self.cache = self.database(self.words, {})
-        lk = None
-        if not self.skip_mp:
-            lk = Lock()
-        # there must be a better way to serialize from the proxy ..
-        local_words = [word for word in self.words]
-        with open(self.brain_file, 'w') as outfile:
-            if not self.skip_mp:
-                lk.acquire()
-            outfile.write(yaml.dump(local_words, default_flow_style=True))
-            if not self.skip_mp:
-                lk.release()
-
     def create_response(self, prompt="", learn=False):
-        prompt_tokens = prompt.split()
-
         # set seedword from somewhere in words if there's no prompt
-        if len(prompt_tokens) < 1:
-            seed = random.randint(0, len(self.words)-1)
-            prompt_tokens.append(self.words[seed])
-
-        # create a set of lookups for phrases that start with words
-        # contained in prompt phrase
-        seed_tuples = []
-        for i in range(0, len(prompt_tokens)-2):
-            seed_phrase = ("<START>", prompt_tokens[i])
-            seed_tuples.append(seed_phrase)
-
-        # lookup seeds in cache; compile a list of 'hits'
-        seed_phrase = None
-        valid_seeds = []
-        for seed in seed_tuples:
-            if seed in self.cache:
-                valid_seeds.append(seed)
-
-        # either seed the lookup with a randomly selected valid seed,
-        # or if there were no 'hits' generate with no seedphrase
-        if len(valid_seeds) > 0:
-            seed_phrase = valid_seeds[random.randrange(0, len(valid_seeds), 1)]
-            response = self.generate_markov_text(self.words, self.cache, seed_phrase)
-        else:
-            response = self.generate_markov_text(self.words, self.cache)
-
+        prompt_tokens = prompt.split()
+        valid_seeds = [tok for tok in prompt_tokens[:-2] if tok in self.graph]
+        seed_word = random.choice(valid_seeds) if valid_seeds else None
+        response = self.generate_markov_text(seed_word)
         if learn:
-            if not self.skip_mp:
-                p = Process(target=self.learn, args=(prompt,))
-                p.start()
-            else:
-                self.learn(prompt)
+            self.update_graph_and_corpus(self.tokenize(prompt))
         return response


### PR DESCRIPTION
* style fixes

* some optimizations for markov generation

cache start words separately to avoid scans. avoid storing useless grams

* avoid linear operation when choosing seed

* reorder methods

* incremental updates for in-memory markov db

* eliminate multiprocessing and improve efficiency

- read brain from either yaml or plain text
- write learned corpus by appending to a plain text file
- use generators where possible to avoid big reads
- don't write new phrases if we don't learn from them
- get rid of <START> and <STOP> tokens, they can be implicit in the corpus

This should make us performant enough we can forgo multiprocessing and do everything in-process